### PR TITLE
Use public Cubism submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Cubism"]
 	path = Cubism
-	url = git@gitlab.ethz.ch:/mavt-cse/Cubism
+	url = git@github.com:/novatig/Cubism


### PR DESCRIPTION
The current submodule links to a private git repo of Cubism.
This PR changes it to the public GitHub repo instead.